### PR TITLE
Fix error in Login saga ([PEER20-311] Change text of error message for registered user with wrong password)

### DIFF
--- a/app/containers/Login/saga.js
+++ b/app/containers/Login/saga.js
@@ -119,13 +119,14 @@ export function* loginWithEmailWorker({ val }) {
       rememberMe,
       ethereumService,
     );
-    ethereumService.setSelectedAccount(response.body.address);
 
     if (!response.OK) {
       throw new WebIntegrationError(
         translations[webIntegrationErrors[response.errorCode].id],
       );
     }
+
+    ethereumService.setSelectedAccount(response.body.address);
 
     yield put(addLoginData(response.peeranhaAutoLogin));
     yield call(continueLogin, response.body);


### PR DESCRIPTION
**This problem solves by sending right response from peeranha-api. The only problem here is accessing the field before verifying the success of the request.**

> Change text of error message for registered user with wrong password
> 
> When registered user tries to log in with email and entering an incorrect password, ‘An error occured’ message is displayed.  But it must be “Entered password is incorrect” error message  displayed at the top right corner of the page