### PR TITLE
[PEER-110] Post type icons are not displayed for "All communities" filter on post-related pages

### DIFF
--- a/app/containers/Questions/Content/Body/index.js
+++ b/app/containers/Questions/Content/Body/index.js
@@ -48,7 +48,6 @@ const Body = ({
   postType,
   isFeed,
   isExpert,
-  isCommunityFeed,
 }) => {
   // const [visible, changeVisibility] = useState(false);
 
@@ -71,7 +70,7 @@ const Body = ({
           topQuestionsCount={topQuestionsCount}
           topQuestionActionProcessing={topQuestionActionProcessing}
         />
-        {(isFeed || isSearchPage || isCommunityFeed) && (
+        {(isFeed || isSearchPage) && (
           <QuestionType
             locale={locale}
             postType={postType}

--- a/app/containers/Questions/index.js
+++ b/app/containers/Questions/index.js
@@ -206,8 +206,6 @@ export const Questions = ({
     [profile],
   );
 
-  const isCommunityFeed = params.hasOwnProperty('communityid');
-
   const questionFilterFromCookies = getCookie(QUESTION_FILTER);
   return display ? (
     <div>
@@ -243,7 +241,6 @@ export const Questions = ({
         >
           <Content
             isFeed={isFeed}
-            isCommunityFeed={isCommunityFeed}
             questionsList={questionsList}
             // promotedQuestionsList={
             //   promotedQuestions[+questionFilterFromCookies ? 'top' : 'all']


### PR DESCRIPTION
Additional changes to PEER-115:
- Remove unnecessary property isCommunityFeed